### PR TITLE
Add test, and fix, exclusion of deep level deps.

### DIFF
--- a/lib/loadbuilder/builder.js
+++ b/lib/loadbuilder/builder.js
@@ -71,7 +71,7 @@ util.extend(Builder.prototype, {
     var excludes;
 
     if (ex.assets) {
-      excludes = ex.assets.map(function(dep) { return dep.id });
+      excludes = ex.collectedAssets().map(function(dep) { return dep.id });
     } else {
       excludes = [].slice.call(arguments);
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "loadbuilder",
-    "version": "0.2.7",
+    "version": "0.2.8",
     "description": "Combine and compress dependency chains created by Loadrunner",
     "contributors": [{ "name": "Dan Webb", "email": "dan@danwebb.net" }, { "name": "Kenneth Kufluk", "email": "kenneth@kufluk.com" }],
     "homepage": "https://github.com/danwrong/loadbuilder",

--- a/test/builder.js
+++ b/test/builder.js
@@ -58,10 +58,19 @@ module.exports = {
     );
   },
   testShouldBeAbleToExcludeABundle: function() {
-    var a = builder(opts).include('fixtures/dep1.js', 'fixtures/dep2.js');
+    var a = builder(opts).include('fixtures/dep1.js', 'fixtures/dep2.js'),
+        result = builder(opts).include('fixtures/has_dep.js').exclude(a).toSource();
     assert.equal(
       "using('fixtures/dep1.js', 'fixtures/dep2.js');",
-      builder(opts).include('fixtures/has_dep.js').exclude(a).toSource()
+      result
+    );
+  },
+  testShouldBeAbleToExcludeADeepDep: function() {
+    var a = builder(opts).include('mod_with_dep'),
+        result = builder(opts).include('mod_with_same_dep').exclude(a).toSource();
+    assert.equal(
+      "provide(\"mod_with_same_dep\", function(exports) {\n    using(\"named\", function() {\n        exports(3);\n    });\n});",
+      result
     );
   },
   testShouldBeAbleToExcludeABundleWithoutBreakingCommonJS: function() {

--- a/test/modules/mod_with_same_dep.js
+++ b/test/modules/mod_with_same_dep.js
@@ -1,0 +1,5 @@
+provide(function(exports) {
+  using('named', function() {
+    exports(3);
+  });
+});


### PR DESCRIPTION
My previous fix doesn't seem to have worked.
This adds a proper new test.

Problem is excluding deep deps of one bundle from another.
a= builder.include('bundle including xxx')
b= otherbuilder.exclude(a)
b should not include xxx, but currently does.

I've tested this fix against Twitter this time.  It works.
