### PR TITLE
Add an includeInManifest option to bundles

### DIFF
--- a/lib/loadbuilder/builder.js
+++ b/lib/loadbuilder/builder.js
@@ -69,7 +69,8 @@ Builder.defaultOptions = {
   docroot: process.cwd(),
   includeDependencies: true,
   preProcessor: null,
-  translationFunctionName: '_'
+  translationFunctionName: '_',
+  includeInManifest: true
 };
 
 util.extend(Builder.prototype, {
@@ -212,7 +213,9 @@ util.extend(Builder.prototype, {
       hash = util.hashString(src, this.options.hashSalt);
       filename = filename.replace('<hash>', hash);
     }
-    res[filename] = manifest;
+    if (this.options.includeInManifest) {
+      res[filename] = manifest;
+    }
 
     fs.writeFile(
       filename,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "loadbuilder",
-    "version": "0.4.4",
+    "version": "0.4.5",
     "description": "Combine and compress dependency chains created by Loadrunner",
     "contributors": [{ "name": "Dan Webb", "email": "dan@danwebb.net" }, { "name": "Kenneth Kufluk", "email": "kenneth@kufluk.com" }],
     "homepage": "https://github.com/danwrong/loadbuilder",

--- a/test/builder_test.js
+++ b/test/builder_test.js
@@ -54,6 +54,23 @@ module.exports = {
       builder(opts).include('fixtures/has_dep.js').manifest()
     );
   },
+  testShouldExcludeFromManifestList: function() {
+    var opts = {
+      docroot: __dirname,
+      path: 'modules',
+      hashSalt: '7',
+      includeInManifest: false
+    };
+    var path = __dirname + '/bundle-no-manifest.js';
+    // Manifest is only excluded in callback from write
+    builder(opts).include('fixtures/has_dep.js').write(path, function(manifest) {
+      assert.deepEqual(
+        {},
+        manifest
+      );
+      fs.unlinkSync(path);
+    });
+  },
   testShouldExcludeDependenciesOfExcludedAsset: function() {
     assert.equal(
       "alert('hello');\nusing('fixtures/dep1.js', 'fixtures/dep2.js');",


### PR DESCRIPTION
Add an includeInManifest option to the bundle, so that we can exclude certain bundles from the manifest file.
